### PR TITLE
Fix image links in README so Atom page can load them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SyntaxDB Atom Plugin
 
-![Front](screenshots/front.png)
+![Front](https://github.com/Coteh/syntaxdb-atom-plugin/blob/master/screenshots/front.png)
 
 An atom package that provides a simple interface to search and view the [SyntaxDB](https://syntaxdb.com/) database.
 
@@ -11,20 +11,20 @@ Either clone this repo into your packages directory or download it from the atom
 To use the atom package, make sure it's installed, then press Ctrl-Alt-S to activate the SyntaxDB search panel.
 To activate the language filter, which displays all concepts on the SyntaxDB database by language, press Ctrl-Alt-L.
 
-![Search View](screenshots/SearchView.gif)  
+![Search View](https://github.com/Coteh/syntaxdb-atom-plugin/blob/master/screenshots/SearchView.gif)  
 *SyntaxDB plugin search bar*
 
 On the search panel, type in a search query (eg. "for loop in Java") and press enter. A list view will then appear, displaying the results
 it has gathered from the SyntaxDB API. Selecting any of these results will bring up a results view for the entry, displaying
 its syntax as well as additional information.
 
-![Results View](screenshots/ResultsView.gif)  
+![Results View](https://github.com/Coteh/syntaxdb-atom-plugin/blob/master/screenshots/ResultsView.gif)  
 *Currently, the results view displays notes, syntax, example(s), and documentation about the specified syntax.*
 
 It is also possible to place the syntax example provided by SyntaxDB directly into your document. To do this, make sure the Example tab
 is currently selected, then press the "Place in Document" button. (or press shift-enter)
 
-![Placing Example into Document](screenshots/PlaceExample.gif)  
+![Placing Example into Document](https://github.com/Coteh/syntaxdb-atom-plugin/blob/master/screenshots/PlaceExample.gif)  
 *Example of placing an example into a document.*
 
 # Issues


### PR DESCRIPTION
Absolute link to promo images so that the Atom plugin page can properly load them.

https://atom.io/packages/syntaxdb-atom-plugin
