### PR TITLE
Add search lock.

### DIFF
--- a/lib/SyntaxSearch.js
+++ b/lib/SyntaxSearch.js
@@ -6,6 +6,11 @@ import { LanguageFilterMode } from './SyntaxModes';
 import request from "request";
 
 export default class SyntaxSearch extends SyntaxModel {
+    constructor() {
+        super();
+        this.searchLock = false;
+    }
+
     setViews(views) {
         if (!views) {
             return;
@@ -64,10 +69,18 @@ export default class SyntaxSearch extends SyntaxModel {
     }
 
     performSearch(result) {
+        //Only perform search if there's no search that's currently going on
+        if (this.searchLock) {
+            return;
+        }
         var _this = this;
+        //Turn on the lock
+        this.searchLock = true;
         request("http://syntaxdb.com/api/v1/concepts/search?q=" + result.searchText, function(error, response, body){
             results = JSON.parse(body);
             _this.onRequestReceived(results, {searchQuery: result.searchText, show: true});
+            //Turn off the lock since search is done
+            _this.searchLock = false;
         });
     }
 


### PR DESCRIPTION
Fixes #1.
Since the request calls are asynchronous, if the user presses enter to search more than once, multiple search queries will fire and each one that finishes will display their results on the search results view overwriting the previous, with the last results view update coming from the last search query to finish. This PR fixes the issue by implementing a search lock that will prevent any more search queries to fire until the current one finishes.