### PR TITLE
Sanitize search input

### DIFF
--- a/lib/PercentEncoder.js
+++ b/lib/PercentEncoder.js
@@ -1,5 +1,26 @@
 'use babel';
 
+let reservedMap = new Map([
+    ['!', 1],
+    ['#', 1],
+    ['$', 1],
+    ['&', 1],
+    ['\'', 1],
+    ['(', 1],
+    [')', 1],
+    ['*', 1],
+    ['+', 1],
+    [',', 1],
+    [':', 1],
+    [';', 1],
+    ['=', 1],
+    ['?', 1],
+    ['@', 1],
+    ['[', 1],
+    [']', 1],
+    ['%', 1],
+]);
+
 export default class PercentEncoder {
     static percentEncodeChar(char) {
         return "%" + char.charCodeAt(0).toString(16);
@@ -8,9 +29,12 @@ export default class PercentEncoder {
         var result = "";
 
         for (var i = 0; i < str.length; i++) {
-            result += this.percentEncodeChar(str[i]);
+            result += (this.isReservedChar(str[i])) ? this.percentEncodeChar(str[i]) : str[i];
         }
 
         return result;
+    }
+    static isReservedChar(char) {
+        return reservedMap.has(char);
     }
 }

--- a/lib/PercentEncoder.js
+++ b/lib/PercentEncoder.js
@@ -1,0 +1,16 @@
+'use babel';
+
+export default class PercentEncoder {
+    static percentEncodeChar(char) {
+        return "%" + char.charCodeAt(0).toString(16);
+    }
+    static percentEncodeStr(str) {
+        var result = "";
+
+        for (var i = 0; i < str.length; i++) {
+            result += this.percentEncodeChar(str[i]);
+        }
+
+        return result;
+    }
+}

--- a/lib/SyntaxSearch.js
+++ b/lib/SyntaxSearch.js
@@ -3,6 +3,7 @@
 import SyntaxModel from './SyntaxModel';
 import ResultsPresenter from "./ResultsPresenter";
 import { LanguageFilterMode } from './SyntaxModes';
+import PercentEncoder from './PercentEncoder';
 import request from "request";
 
 export default class SyntaxSearch extends SyntaxModel {
@@ -73,10 +74,14 @@ export default class SyntaxSearch extends SyntaxModel {
         if (this.searchLock) {
             return;
         }
+        //Save a copy of reference to this, for the request callback
         var _this = this;
         //Turn on the lock
         this.searchLock = true;
-        request("http://syntaxdb.com/api/v1/concepts/search?q=" + result.searchText, function(error, response, body){
+        //Percent encode search term
+        var percentEncoded = PercentEncoder.percentEncodeStr(result.searchText);
+        //Perform the search
+        request("http://syntaxdb.com/api/v1/concepts/search?q=" + percentEncoded, function(error, response, body){
             results = JSON.parse(body);
             _this.onRequestReceived(results, {searchQuery: result.searchText, show: true});
             //Turn off the lock since search is done


### PR DESCRIPTION
Fixes #9.
When a search term is fed into the request module, special characters such as the '+' character are ignored because they are reserved characters that have a special purpose in a URL. Because of this, special characters have to be percent encoded on the plugin end so that a GET request can be made to SyntaxDB with those special characters in the search term as if they were just regular characters.