### PR TITLE
Fix focus element leaking by setting opacity=0

### DIFF
--- a/lib/SyntaxCSS.js
+++ b/lib/SyntaxCSS.js
@@ -1,0 +1,19 @@
+'use babel';
+
+export default class SyntaxCSS {
+    static visibleFocusElement() {
+        return {
+            position: "static",
+            top: "auto",
+            opacity: "initial"
+        };
+    }
+
+    static invisibleFocusElement() {
+        return {
+            position: "absolute",
+            top: "-100px",
+            opacity: "0"
+        };
+    }
+}

--- a/lib/SyntaxFilterView.js
+++ b/lib/SyntaxFilterView.js
@@ -2,8 +2,9 @@
 
 AtomSpacePenViews = require('atom-space-pen-views');
 SelectListView = AtomSpacePenViews.SelectListView;
-import { LanguageFilterMode } from './SyntaxModes'
-import { Emitter } from 'atom'
+import { LanguageFilterMode } from './SyntaxModes';
+import SyntaxCSS from './SyntaxCSS';
+import { Emitter } from 'atom';
 
 export default class SyntaxFilterView extends SelectListView {
 
@@ -42,16 +43,10 @@ export default class SyntaxFilterView extends SelectListView {
       if (items.length == 0) {
           //then "hide" the filter text editor, but keep
           //it visible so we can still close the panel with ESC key
-          this.filterEditorView.css({
-              position: "absolute",
-              top: "-100px"
-          });
+          this.filterEditorView.css(SyntaxCSS.invisibleFocusElement());
       } else {
           //otherwise, set it to "visible" (aka put it in a position where we can see it)
-          this.filterEditorView.css({
-              position: "static",
-              top: "auto"
-          });
+          this.filterEditorView.css(SyntaxCSS.visibleFocusElement());
       }
   }
 

--- a/lib/SyntaxResultDocumentationTab.js
+++ b/lib/SyntaxResultDocumentationTab.js
@@ -1,6 +1,7 @@
 'use babel';
 
-import SyntaxResultTab from "./SyntaxResultTab"
+import SyntaxResultTab from "./SyntaxResultTab";
+import SyntaxCSS from './SyntaxCSS';
 import open from "open";
 import { TextEditor } from 'atom';
 import { $, TextEditorView } from 'atom-space-pen-views';
@@ -18,10 +19,7 @@ export default class SyntaxResultDocumentationTab extends SyntaxResultTab {
     constructor(serializedState) {
         super(serializedState);
 
-        this.focusEditorView.css({
-            position: "absolute",
-            top: "-100px"
-        });
+        this.focusEditorView.css(SyntaxCSS.invisibleFocusElement());
 
         this.focusEditorView.addClass("syntaxdb-result-editor");
     }

--- a/lib/SyntaxResultNotesTab.js
+++ b/lib/SyntaxResultNotesTab.js
@@ -1,6 +1,7 @@
 'use babel';
 
-import SyntaxResultTab from "./SyntaxResultTab"
+import SyntaxResultTab from "./SyntaxResultTab";
+import SyntaxCSS from './SyntaxCSS';
 import { TextEditor } from 'atom';
 import { TextEditorView } from 'atom-space-pen-views';
 
@@ -17,10 +18,7 @@ export default class SyntaxResultNotesTab extends SyntaxResultTab {
     constructor(serializedState) {
         super(serializedState);
 
-        this.focusEditorView.css({
-            position: "absolute",
-            top: "-100px"
-        });
+        this.focusEditorView.css(SyntaxCSS.invisibleFocusElement());
 
         this.focusEditorView.addClass("syntaxdb-result-editor");
     }


### PR DESCRIPTION
Fixes #15.  
Setting the opacity of all affected focus editors to 0 will effectively remove the element from view while still maintaining the ability to focus on the element for keyboard inputs. When making the focus editor visible again, the opacity shall be set back to its initial value, which should be 1.  
The invisible and visible CSS property sets have been added to utility functions for better modularity.