### PR TITLE
Append newline to results editors if none

### DIFF
--- a/lib/SyntaxResultExampleTab.js
+++ b/lib/SyntaxResultExampleTab.js
@@ -2,6 +2,7 @@
 
 import SyntaxResultTab from "./SyntaxResultTab";
 import EditorInserter from "./EditorInserter";
+import SyntaxUtil from "./SyntaxUtil";
 import { TextEditor } from 'atom';
 import { TextEditorView } from 'atom-space-pen-views';
 import { CompositeDisposable } from 'atom';
@@ -48,7 +49,7 @@ export default class SyntaxResultExampleTab extends SyntaxResultTab {
     }
 
     setText(text) {
-        this.resultEditorView.setText(text);
+        this.resultEditorView.setText(SyntaxUtil.newLineizeEditorText(text));
     }
 
     onShow() {

--- a/lib/SyntaxResultSyntaxTab.js
+++ b/lib/SyntaxResultSyntaxTab.js
@@ -1,6 +1,7 @@
 'use babel';
 
-import SyntaxResultTab from "./SyntaxResultTab"
+import SyntaxResultTab from "./SyntaxResultTab";
+import SyntaxUtil from "./SyntaxUtil";
 import { TextEditor } from 'atom';
 import { TextEditorView } from 'atom-space-pen-views';
 
@@ -24,6 +25,6 @@ export default class SyntaxResultSyntaxTab extends SyntaxResultTab {
     }
 
     setText(text) {
-        this.resultEditorView.setText(text);
+        this.resultEditorView.setText(SyntaxUtil.newLineizeEditorText(text));
     }
 }

--- a/lib/SyntaxUtil.js
+++ b/lib/SyntaxUtil.js
@@ -1,0 +1,10 @@
+'use babel';
+
+export default class SyntaxUtil {
+    static newLineizeEditorText(text) {
+        if (text[text.length - 1] != '\n') {
+            return text + "\n";
+        }
+        return text;
+    }
+}

--- a/spec/SyntaxUtil-spec.js
+++ b/spec/SyntaxUtil-spec.js
@@ -1,0 +1,23 @@
+'use babel';
+
+import SyntaxUtil from "../lib/SyntaxUtil";
+
+describe("SyntaxUtil", () => {
+    describe("when newLineizeEditorText util func is used", () => {
+        it("should append a newline to pieces of text without a newline at the end", () => {
+            var beforeText = "This text has no newline.";
+            var expectedText = "This text has no newline.\n";
+            var afterText = SyntaxUtil.newLineizeEditorText(beforeText);
+
+            expect(afterText).toBe(expectedText);
+        });
+
+        it("should NOT append a newline to pieces of text with a newline at the end", () => {
+            var beforeText = "This text has a newline.\n";
+            var expectedText = "This text has a newline.\n";
+            var afterText = SyntaxUtil.newLineizeEditorText(beforeText);
+
+            expect(afterText).toBe(expectedText);
+        });
+    });
+});


### PR DESCRIPTION
When loading the syntax/example text into their respective editors, if there's no newline at the end of the text, then a newline shall be appended to that string before it's sent to the editor. Otherwise, the original string shall be sent to the editor.