### PR TITLE
Add error handling to search and syntax filter modals

### DIFF
--- a/lib/domain/ResultsPresenter.js
+++ b/lib/domain/ResultsPresenter.js
@@ -19,9 +19,8 @@ export default class ResultsPresenter {
 
         this.results = results;
 
-        var _this = this;
-        this.resultView.setCancelAction(function () {
-            _this.hideResults();
+        this.resultView.setCancelAction(() => {
+            this.hideResults();
         });
 
         this.resultView.storeFocusedElement();

--- a/lib/domain/SyntaxAggregator.js
+++ b/lib/domain/SyntaxAggregator.js
@@ -69,6 +69,10 @@ export default class SyntaxAggregator extends SyntaxModel {
                         options.language_permalink +
                         '/categories',
                     function (error, response, body) {
+                        if (error) {
+                            _this.onRequestError();
+                            return;
+                        }
                         let results = JSON.parse(body);
                         _this.currentMode = _filterMode;
                         _this.onRequestReceived(results, options);
@@ -83,6 +87,10 @@ export default class SyntaxAggregator extends SyntaxModel {
                         options.category_id +
                         '/concepts',
                     function (error, response, body) {
+                        if (error) {
+                            _this.onRequestError();
+                            return;
+                        }
                         let results = JSON.parse(body);
                         _this.currentMode = _filterMode;
                         _this.onRequestReceived(results, options);
@@ -95,6 +103,10 @@ export default class SyntaxAggregator extends SyntaxModel {
                     response,
                     body,
                 ) {
+                    if (error) {
+                        _this.onRequestError();
+                        return;
+                    }
                     let results = JSON.parse(body);
                     _this.currentMode = _filterMode;
                     _this.onRequestReceived(results, options);
@@ -130,6 +142,11 @@ export default class SyntaxAggregator extends SyntaxModel {
             }
             this.show();
         }
+    }
+
+    onRequestError() {
+        this.displayMessage('No internet connection');
+        this.show();
     }
 
     onSelect(result) {

--- a/lib/domain/SyntaxAggregator.js
+++ b/lib/domain/SyntaxAggregator.js
@@ -2,7 +2,6 @@
 
 import { LanguageFilterMode } from './SyntaxModes';
 import SyntaxModel from './SyntaxModel';
-import ResultsPresenter from './ResultsPresenter';
 import request from 'request';
 
 export default class SyntaxAggregator extends SyntaxModel {

--- a/lib/domain/SyntaxAggregator.js
+++ b/lib/domain/SyntaxAggregator.js
@@ -25,12 +25,11 @@ export default class SyntaxAggregator extends SyntaxModel {
 
     show() {
         if (this.filterView) {
-            let _this = this;
-            this.filterView.setConfirmAction(function (result) {
-                _this.onSelect(result);
+            this.filterView.setConfirmAction((result) => {
+                this.onSelect(result);
             });
-            this.filterView.setCancelAction(function (result) {
-                _this.onCancel();
+            this.filterView.setCancelAction((result) => {
+                this.onCancel();
             });
             this.filterView.storeFocusedElement();
             this.filterView.showPanel();
@@ -59,7 +58,6 @@ export default class SyntaxAggregator extends SyntaxModel {
     }
 
     performRequest(filterMode, options) {
-        let _this = this;
         let _filterMode = filterMode;
         switch (filterMode) {
             case LanguageFilterMode.SELECT_CATEGORY:
@@ -67,14 +65,14 @@ export default class SyntaxAggregator extends SyntaxModel {
                     'http://syntaxdb.com/api/v1/languages/' +
                         options.language_permalink +
                         '/categories',
-                    function (error, response, body) {
+                    (error, response, body) => {
                         if (error) {
-                            _this.onRequestError(error);
+                            this.onRequestError(error);
                             return;
                         }
                         let results = JSON.parse(body);
-                        _this.currentMode = _filterMode;
-                        _this.onRequestReceived(results, options);
+                        this.currentMode = _filterMode;
+                        this.onRequestReceived(results, options);
                     },
                 );
                 break;
@@ -85,31 +83,30 @@ export default class SyntaxAggregator extends SyntaxModel {
                         '/categories/' +
                         options.category_id +
                         '/concepts',
-                    function (error, response, body) {
+                    (error, response, body) => {
                         if (error) {
-                            _this.onRequestError(error);
+                            this.onRequestError(error);
                             return;
                         }
                         let results = JSON.parse(body);
-                        _this.currentMode = _filterMode;
-                        _this.onRequestReceived(results, options);
+                        this.currentMode = _filterMode;
+                        this.onRequestReceived(results, options);
                     },
                 );
                 break;
             case LanguageFilterMode.SELECT_LANGUAGE:
-                request.get('http://syntaxdb.com/api/v1/languages', function (
-                    error,
-                    response,
-                    body,
-                ) {
-                    if (error) {
-                        _this.onRequestError(error);
-                        return;
-                    }
-                    let results = JSON.parse(body);
-                    _this.currentMode = _filterMode;
-                    _this.onRequestReceived(results, options);
-                });
+                request.get(
+                    'http://syntaxdb.com/api/v1/languages',
+                    (error, response, body) => {
+                        if (error) {
+                            this.onRequestError(error);
+                            return;
+                        }
+                        let results = JSON.parse(body);
+                        this.currentMode = _filterMode;
+                        this.onRequestReceived(results, options);
+                    },
+                );
                 break;
             default:
                 return;

--- a/lib/domain/SyntaxAggregator.js
+++ b/lib/domain/SyntaxAggregator.js
@@ -69,7 +69,7 @@ export default class SyntaxAggregator extends SyntaxModel {
                         '/categories',
                     function (error, response, body) {
                         if (error) {
-                            _this.onRequestError();
+                            _this.onRequestError(error);
                             return;
                         }
                         let results = JSON.parse(body);
@@ -87,7 +87,7 @@ export default class SyntaxAggregator extends SyntaxModel {
                         '/concepts',
                     function (error, response, body) {
                         if (error) {
-                            _this.onRequestError();
+                            _this.onRequestError(error);
                             return;
                         }
                         let results = JSON.parse(body);
@@ -103,7 +103,7 @@ export default class SyntaxAggregator extends SyntaxModel {
                     body,
                 ) {
                     if (error) {
-                        _this.onRequestError();
+                        _this.onRequestError(error);
                         return;
                     }
                     let results = JSON.parse(body);
@@ -143,8 +143,19 @@ export default class SyntaxAggregator extends SyntaxModel {
         }
     }
 
-    onRequestError() {
-        this.displayMessage('No internet connection');
+    onRequestError(error) {
+        if (this.filterView) {
+            if (this.currentMode === LanguageFilterMode.NONE) {
+                this.filterView.setItems([]);
+            }
+            if (error.code === 'ENOTFOUND') {
+                this.filterView.setErrorMessage('No internet connection');
+            } else {
+                this.filterView.setErrorMessage(
+                    'Error connecting to SyntaxDB. Try again later.',
+                );
+            }
+        }
         this.show();
     }
 

--- a/lib/domain/SyntaxSearch.js
+++ b/lib/domain/SyntaxSearch.js
@@ -88,7 +88,7 @@ export default class SyntaxSearch extends SyntaxModel {
             'http://syntaxdb.com/api/v1/concepts/search?q=' + percentEncoded,
             function (error, response, body) {
                 if (error) {
-                    _this.onRequestError();
+                    _this.onRequestError(error);
                     //Unlock since search ran into an error
                     _this.searchLock = false;
                     return;
@@ -160,9 +160,15 @@ export default class SyntaxSearch extends SyntaxModel {
         }
     }
 
-    onRequestError() {
+    onRequestError(error) {
         if (this.searchView) {
-            this.searchView.setLabelMessage('No internet connection');
+            if (error.code === 'ENOTFOUND') {
+                this.searchView.setErrorMessage('No internet connection');
+            } else {
+                this.searchView.setErrorMessage(
+                    'Error connecting to SyntaxDB. Try again later.',
+                );
+            }
         }
     }
 }

--- a/lib/domain/SyntaxSearch.js
+++ b/lib/domain/SyntaxSearch.js
@@ -29,14 +29,12 @@ export default class SyntaxSearch extends SyntaxModel {
 
     showSearch() {
         if (this.searchView) {
-            (function (_this) {
-                _this.searchView.setConfirmAction(function (result) {
-                    _this.performSearch(result);
-                });
-                _this.searchView.setCancelAction(function () {
-                    _this.hideSearch();
-                });
-            })(this);
+            this.searchView.setConfirmAction((result) => {
+                this.performSearch(result);
+            });
+            this.searchView.setCancelAction(() => {
+                this.hideSearch();
+            });
             this.searchView.setLabelMessage(
                 'Enter a concept or a language (e.g. for loop in Java)',
             );
@@ -77,8 +75,6 @@ export default class SyntaxSearch extends SyntaxModel {
         if (this.searchLock) {
             return;
         }
-        //Save a copy of reference to this, for the request callback
-        var _this = this;
         //Turn on the lock
         this.searchLock = true;
         //Percent encode search term
@@ -86,20 +82,20 @@ export default class SyntaxSearch extends SyntaxModel {
         //Perform the search
         request.get(
             'http://syntaxdb.com/api/v1/concepts/search?q=' + percentEncoded,
-            function (error, response, body) {
+            (error, response, body) => {
                 if (error) {
-                    _this.onRequestError(error);
+                    this.onRequestError(error);
                     //Unlock since search ran into an error
-                    _this.searchLock = false;
+                    this.searchLock = false;
                     return;
                 }
                 results = JSON.parse(body);
-                _this.onRequestReceived(results, {
+                this.onRequestReceived(results, {
                     searchQuery: query.searchText,
                     show: true,
                 });
                 //Unlock since search is done
-                _this.searchLock = false;
+                this.searchLock = false;
             },
         );
     }

--- a/lib/domain/SyntaxSearch.js
+++ b/lib/domain/SyntaxSearch.js
@@ -85,6 +85,10 @@ export default class SyntaxSearch extends SyntaxModel {
         request.get(
             'http://syntaxdb.com/api/v1/concepts/search?q=' + percentEncoded,
             function (error, response, body) {
+                if (error) {
+                    _this.onRequestError();
+                    return;
+                }
                 results = JSON.parse(body);
                 _this.onRequestReceived(results, {
                     searchQuery: query.searchText,
@@ -149,6 +153,13 @@ export default class SyntaxSearch extends SyntaxModel {
             if (options && options.show) {
                 this.showSearchResults();
             }
+        }
+    }
+
+    onRequestError() {
+        if (this.filterView) {
+            this.showSearchResults();
+            this.filterView.setLabelMessage('No internet connection');
         }
     }
 }

--- a/lib/domain/SyntaxSearch.js
+++ b/lib/domain/SyntaxSearch.js
@@ -103,10 +103,7 @@ export default class SyntaxSearch extends SyntaxModel {
     showSearchResults() {
         if (this.filterView) {
             this.filterView.setConfirmAction((result) => {
-                this.filterView.restoreFocus();
-                if (result && result.item) {
-                    this.resultsPresenter.showResults(result, this.resultView);
-                }
+                this.selectSearchResult(result);
             });
             this.filterView.setCancelAction(() => {
                 this.hideSearchResults();
@@ -129,6 +126,13 @@ export default class SyntaxSearch extends SyntaxModel {
             this.filterView.restoreFocus();
         } else {
             throw new Error('No filter view provided');
+        }
+    }
+
+    selectSearchResult(result) {
+        this.filterView.restoreFocus();
+        if (result && result.item) {
+            this.resultsPresenter.showResults(result, this.resultView);
         }
     }
 

--- a/lib/domain/SyntaxSearch.js
+++ b/lib/domain/SyntaxSearch.js
@@ -87,6 +87,8 @@ export default class SyntaxSearch extends SyntaxModel {
             function (error, response, body) {
                 if (error) {
                     _this.onRequestError();
+                    //Unlock since search ran into an error
+                    _this.searchLock = false;
                     return;
                 }
                 results = JSON.parse(body);
@@ -94,7 +96,7 @@ export default class SyntaxSearch extends SyntaxModel {
                     searchQuery: query.searchText,
                     show: true,
                 });
-                //Turn off the lock since search is done
+                //Unlock since search is done
                 _this.searchLock = false;
             },
         );

--- a/lib/domain/SyntaxSearch.js
+++ b/lib/domain/SyntaxSearch.js
@@ -1,7 +1,6 @@
 'use babel';
 
 import SyntaxModel from './SyntaxModel';
-import ResultsPresenter from './ResultsPresenter';
 import { LanguageFilterMode } from './SyntaxModes';
 import { percentEncode } from '../util/PercentEncode';
 import request from 'request';
@@ -38,6 +37,9 @@ export default class SyntaxSearch extends SyntaxModel {
                     _this.hideSearch();
                 });
             })(this);
+            this.searchView.setLabelMessage(
+                'Enter a concept or a language (e.g. for loop in Java)',
+            );
             this.searchView.showPanel();
             this.searchView.storeFocusedElement();
             this.searchView.focus();
@@ -159,9 +161,8 @@ export default class SyntaxSearch extends SyntaxModel {
     }
 
     onRequestError() {
-        if (this.filterView) {
-            this.showSearchResults();
-            this.filterView.setLabelMessage('No internet connection');
+        if (this.searchView) {
+            this.searchView.setLabelMessage('No internet connection');
         }
     }
 }

--- a/lib/view/SyntaxFilterView.js
+++ b/lib/view/SyntaxFilterView.js
@@ -138,6 +138,12 @@ export default class SyntaxFilterView extends SelectListView {
     }
 
     setLabelMessage(message) {
+        this.searchLabel.style.color = '';
+        this.searchLabel.textContent = message;
+    }
+
+    setErrorMessage(message) {
+        this.searchLabel.style.color = 'red';
         this.searchLabel.textContent = message;
     }
 }

--- a/lib/view/SyntaxResultView.js
+++ b/lib/view/SyntaxResultView.js
@@ -83,8 +83,7 @@ export default class SyntaxResultView extends View {
     }
 
     addTabs(tabs) {
-        var _this = this;
-        tabs.forEach(function (item, index, array) {
+        tabs.forEach((item, index, array) => {
             //Required properties
             if (!item.name || !item.tab) {
                 //TODO
@@ -95,10 +94,10 @@ export default class SyntaxResultView extends View {
             var newBtn = $('<button class="btn">' + item.name + '</button>');
             item.button = newBtn;
             item.index = index;
-            _this.tabsList.push(item);
-            _this.tabDiv.append(newBtn);
+            this.tabsList.push(item);
+            this.tabDiv.append(newBtn);
             newBtn.on('click', () => {
-                _this.switchTab(item.name);
+                this.switchTab(item.name);
             });
         });
     }

--- a/lib/view/SyntaxSearchView.js
+++ b/lib/view/SyntaxSearchView.js
@@ -47,16 +47,12 @@ export default class SyntaxSearchView extends View {
         );
 
         //on 'blur' events (such as tab key press)
-        (function (_this) {
-            _this.searchBarEditorView.on('blur', function (e) {
-                //cancel out if it's not currently cancelling and document has focus
-                console.log(_this.cancelling);
-                console.log(document.hasFocus());
-                if (!_this.cancelling && document.hasFocus()) {
-                    _this.cancel();
-                }
-            });
-        })(this);
+        this.searchBarEditorView.on('blur', (e) => {
+            //cancel out if it's not currently cancelling and document has focus
+            if (!this.cancelling && document.hasFocus()) {
+                this.cancel();
+            }
+        });
 
         this.panel = atom.workspace.addModalPanel({
             item: this.getElement(),

--- a/lib/view/SyntaxSearchView.js
+++ b/lib/view/SyntaxSearchView.js
@@ -28,10 +28,6 @@ export default class SyntaxSearchView extends View {
 
         this.cancelling = false;
 
-        this.searchLabel.text(
-            'Enter a concept or a language (e.g. for loop in Java)',
-        );
-
         this.eventEmitter = new Emitter();
 
         this.addClass('syntaxdb-search');
@@ -161,5 +157,9 @@ export default class SyntaxSearchView extends View {
 
     getElement() {
         return this.element;
+    }
+
+    setLabelMessage(message) {
+        this.searchLabel.text(message);
     }
 }

--- a/lib/view/SyntaxSearchView.js
+++ b/lib/view/SyntaxSearchView.js
@@ -160,6 +160,14 @@ export default class SyntaxSearchView extends View {
     }
 
     setLabelMessage(message) {
+        this.searchLabel.css('color', '');
+        this.searchLabel.text(message);
+    }
+
+    setErrorMessage(message) {
+        this.searchLabel.css({
+            color: 'red',
+        });
         this.searchLabel.text(message);
     }
 }

--- a/lib/view/tab/SyntaxResultExampleTab.js
+++ b/lib/view/tab/SyntaxResultExampleTab.js
@@ -69,9 +69,8 @@ export default class SyntaxResultExampleTab extends SyntaxResultTab {
 
     onShow() {
         super.onShow();
-        var _this = this;
         this.placeBtn.on('click', () => {
-            _this.onPlaceButtonClick();
+            this.onPlaceButtonClick();
         });
     }
 

--- a/lib/view/tab/SyntaxResultTab.js
+++ b/lib/view/tab/SyntaxResultTab.js
@@ -23,9 +23,9 @@ export default class SyntaxResultTab extends View {
 
     // Callback for tab-related actions once it shows up on the panel.
     onShow() {
-        var _this = this;
         $(this.getElement()).on('click', (e) => {
-            _this.focus();
+            this.focus();
+            console.log('click me: ', this);
             e.stopImmediatePropagation();
         });
     }

--- a/lib/view/tab/SyntaxResultTab.js
+++ b/lib/view/tab/SyntaxResultTab.js
@@ -25,7 +25,6 @@ export default class SyntaxResultTab extends View {
     onShow() {
         $(this.getElement()).on('click', (e) => {
             this.focus();
-            console.log('click me: ', this);
             e.stopImmediatePropagation();
         });
     }

--- a/spec/SyntaxAggregator-spec.js
+++ b/spec/SyntaxAggregator-spec.js
@@ -334,4 +334,183 @@ describe('SyntaxAggregator', () => {
             });
         });
     });
+
+    describe("when there's an error performing request to SyntaxDB API", () => {
+        let getStub;
+
+        beforeEach(() => {
+            getStub = sinon.stub(request, 'get');
+        });
+        describe("when there's no internet connection", () => {
+            it('should display a message saying no internet connection', () => {
+                expect(getStub).to.not.have.been.called;
+                expect(filterView.showPanel).to.not.have.been.called;
+                expect(filterView.setErrorMessage).to.not.have.been.called;
+
+                syntaxAggregator.toggle();
+                getStub.yield(
+                    {
+                        code: 'ENOTFOUND',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+                expect(filterView.showPanel).to.have.been.calledOnce;
+                expect(filterView.setErrorMessage).to.have.been.calledOnceWith(
+                    sinon.match('No internet connection'),
+                );
+            });
+        });
+        describe("when there's an unknown error", () => {
+            it('should display a message saying there was an error', () => {
+                expect(getStub).to.not.have.been.called;
+                expect(filterView.showPanel).to.not.have.been.called;
+                expect(filterView.setErrorMessage).to.not.have.been.called;
+
+                syntaxAggregator.toggle();
+                getStub.yield(
+                    {
+                        code: 'ESOMEERROR',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+                expect(filterView.showPanel).to.have.been.calledOnce;
+                expect(filterView.setErrorMessage).to.have.been.calledOnceWith(
+                    sinon.match('Error connecting to SyntaxDB'),
+                );
+            });
+        });
+        describe('when initially opening the filter', () => {
+            it('should not show any results', () => {
+                expect(getStub).to.not.have.been.called;
+                expect(filterView.setItems).to.not.have.been.called;
+
+                syntaxAggregator.toggle();
+                getStub.yield(
+                    {
+                        code: 'ESOMEERROR',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+                expect(filterView.showPanel).to.have.been.calledOnce;
+
+                expect(filterView.setItems).to.have.been.calledWith([]);
+            });
+        });
+        describe('when selecting language result item', () => {
+            it('should not alter the results list', () => {
+                expect(getStub).to.not.have.been.called;
+                expect(filterView.setItems).to.not.have.been.called;
+                syntaxAggregator.currentMode =
+                    LanguageFilterMode.SELECT_LANGUAGE;
+
+                syntaxAggregator.onSelect({
+                    item: {
+                        language_permalink: 'csharp',
+                    },
+                    mode: LanguageFilterMode.SELECT_LANGUAGE,
+                });
+                getStub.yield(
+                    {
+                        code: 'ESOMEERROR',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+
+                expect(filterView.setItems).to.not.have.been.called;
+            });
+        });
+        describe('when selecting category result item', () => {
+            it('should not alter the results list', () => {
+                expect(getStub).to.not.have.been.called;
+                expect(filterView.setItems).to.not.have.been.called;
+                syntaxAggregator.currentMode =
+                    LanguageFilterMode.SELECT_CATEGORY;
+
+                syntaxAggregator.onSelect({
+                    item: {
+                        language_permalink: 'csharp',
+                        id: 25,
+                    },
+                    mode: LanguageFilterMode.SELECT_CATEGORY,
+                });
+                getStub.yield(
+                    {
+                        code: 'ESOMEERROR',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+
+                expect(filterView.setItems).to.not.have.been.called;
+            });
+        });
+        describe('when selecting concept result item', () => {
+            let concept = {
+                id: 210,
+                concept_name: 'Variable Declaration',
+                category_id: 25,
+                position: 8,
+                language_id: 4,
+                concept_search: 'Variable Declaration in C#',
+                concept_permalink: 'variable-dec',
+                description:
+                    'Used to declare a variable. Variables can be implicitly or explicitly typed.\r\n\r\nVariables declared this way (without a static modifier) within classes are called instance variables. They belong to an instance of the class (i.e. an object).',
+                syntax:
+                    'modifier dataType variableName; ///modifier is optional\r\n\r\n///variables can be assigned values either separately or on declaration\r\nvariableName = value; ///separate line assignment\r\n\r\nmodifier dataType variableName = value; ///same line assignment\r\n\r\n///implicitly typed variable\r\nvar variable2 = value;',
+                notes:
+                    'The modifier (public, private) permits or restricts direct access to the variable with respect to its scope (class, method, etc.). Variables declared within a class are called fields.\r\n\r\nVariables without a modifier are known as local variables, typically used within a method. They are temporary and only exist within the scope of the where its declared method.\r\n\r\ndataType is the data type of the variable. ',
+                example:
+                    'public class Car { \r\n    private int speed; ///private variable declaration\r\n    public int wheels; ///public variable declaration\r\n    \r\n    /*...constructor, etc...*/\r\n\r\n    public void speedUp() {\r\n        ///local variable declaration, in line assignment, only seen within speedUp method\r\n        int speedIncrease = 10;\r\n        speed += speedIncrease;\r\n    }\r\n}',
+                keywords: 'fields',
+                related:
+                    '<a href="/ref/csharp/access-mod">Access Modifiers</a>\r\n<a href="/ref/csharp/data-types">Primitive Data Types</a>',
+                documentation:
+                    '<a href="https://msdn.microsoft.com/en-us/library/ms173104.aspx">Types (C# Programming Reference) - MSDN</a>',
+                language_permalink: 'csharp',
+            };
+
+            it('should present the result', () => {
+                expect(getStub).to.not.have.been.called;
+                expect(filterView.setItems).to.not.have.been.called;
+                expect(resultsPresenter.showResults).to.not.have.been.called;
+
+                syntaxAggregator.currentMode =
+                    LanguageFilterMode.SELECT_CONCEPT;
+
+                expect(resultsPresenter.showResults).to.not.have.been.called;
+                syntaxAggregator.onSelect({
+                    item: concept,
+                    mode: LanguageFilterMode.SELECT_CONCEPT,
+                });
+
+                expect(getStub).to.not.have.been.called;
+                expect(filterView.setItems).to.not.have.been.called;
+                expect(resultsPresenter.showResults).to.have.been.calledOnce;
+                expect(resultsPresenter.showResults).to.have.been.calledWith(
+                    {
+                        item: concept,
+                        mode: LanguageFilterMode.SELECT_CONCEPT,
+                    },
+                    resultView,
+                );
+            });
+        });
+        afterEach(() => {
+            getStub.restore();
+        });
+    });
 });

--- a/spec/SyntaxSearch-spec.js
+++ b/spec/SyntaxSearch-spec.js
@@ -130,6 +130,47 @@ describe('SyntaxSearch', () => {
         });
     });
 
+    describe('when search result selected', () => {
+        let concept = {
+            id: 210,
+            concept_name: 'Variable Declaration',
+            category_id: 25,
+            position: 8,
+            language_id: 4,
+            concept_search: 'Variable Declaration in C#',
+            concept_permalink: 'variable-dec',
+            description:
+                'Used to declare a variable. Variables can be implicitly or explicitly typed.\r\n\r\nVariables declared this way (without a static modifier) within classes are called instance variables. They belong to an instance of the class (i.e. an object).',
+            syntax:
+                'modifier dataType variableName; ///modifier is optional\r\n\r\n///variables can be assigned values either separately or on declaration\r\nvariableName = value; ///separate line assignment\r\n\r\nmodifier dataType variableName = value; ///same line assignment\r\n\r\n///implicitly typed variable\r\nvar variable2 = value;',
+            notes:
+                'The modifier (public, private) permits or restricts direct access to the variable with respect to its scope (class, method, etc.). Variables declared within a class are called fields.\r\n\r\nVariables without a modifier are known as local variables, typically used within a method. They are temporary and only exist within the scope of the where its declared method.\r\n\r\ndataType is the data type of the variable. ',
+            example:
+                'public class Car { \r\n    private int speed; ///private variable declaration\r\n    public int wheels; ///public variable declaration\r\n    \r\n    /*...constructor, etc...*/\r\n\r\n    public void speedUp() {\r\n        ///local variable declaration, in line assignment, only seen within speedUp method\r\n        int speedIncrease = 10;\r\n        speed += speedIncrease;\r\n    }\r\n}',
+            keywords: 'fields',
+            related:
+                '<a href="/ref/csharp/access-mod">Access Modifiers</a>\r\n<a href="/ref/csharp/data-types">Primitive Data Types</a>',
+            documentation:
+                '<a href="https://msdn.microsoft.com/en-us/library/ms173104.aspx">Types (C# Programming Reference) - MSDN</a>',
+            language_permalink: 'csharp',
+        };
+
+        it('should present result', () => {
+            expect(resultsPresenter.showResults).to.not.have.been.called;
+
+            syntaxSearch.selectSearchResult({
+                item: concept,
+            });
+
+            expect(resultsPresenter.showResults).to.have.been.calledWithExactly(
+                {
+                    item: concept,
+                },
+                resultView,
+            );
+        });
+    });
+
     describe("when views aren't provided", () => {
         beforeEach(() => {
             syntaxSearch = new SyntaxSearch();
@@ -169,6 +210,121 @@ describe('SyntaxSearch', () => {
                     'No filter view provided',
                 );
             });
+        });
+    });
+
+    describe("when there's an error performing request to SyntaxDB API", () => {
+        let getStub;
+
+        beforeEach(() => {
+            getStub = sinon.stub(request, 'get');
+        });
+        describe("when there's no internet connection", () => {
+            it('should display a message saying no internet connection', () => {
+                expect(getStub).to.not.have.been.called;
+
+                syntaxSearch.performSearch({
+                    searchText: 'for loop',
+                });
+                getStub.yield(
+                    {
+                        code: 'ENOTFOUND',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+                expect(searchView.setErrorMessage).to.have.been.calledOnceWith(
+                    sinon.match('No internet connection'),
+                );
+            });
+        });
+        describe("when there's an unknown error", () => {
+            it('should display a message saying there was an error', () => {
+                expect(getStub).to.not.have.been.called;
+
+                syntaxSearch.performSearch({
+                    searchText: 'for loop',
+                });
+                getStub.yield(
+                    {
+                        code: 'ESOMEERROR',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+                expect(searchView.setErrorMessage).to.have.been.calledOnceWith(
+                    sinon.match('Error connecting to SyntaxDB'),
+                );
+            });
+        });
+        describe('when performing a search', () => {
+            it('should not show the search results view', () => {
+                expect(getStub).to.not.have.been.called;
+
+                syntaxSearch.performSearch({
+                    searchText: 'for loop',
+                });
+                getStub.yield(
+                    {
+                        code: 'ESOMEERROR',
+                    },
+                    null,
+                    null,
+                );
+
+                expect(getStub).to.have.been.calledOnce;
+                expect(filterView.showPanel).to.not.have.been.called;
+            });
+        });
+        describe('when selecting concept result item', () => {
+            let concept = {
+                id: 210,
+                concept_name: 'Variable Declaration',
+                category_id: 25,
+                position: 8,
+                language_id: 4,
+                concept_search: 'Variable Declaration in C#',
+                concept_permalink: 'variable-dec',
+                description:
+                    'Used to declare a variable. Variables can be implicitly or explicitly typed.\r\n\r\nVariables declared this way (without a static modifier) within classes are called instance variables. They belong to an instance of the class (i.e. an object).',
+                syntax:
+                    'modifier dataType variableName; ///modifier is optional\r\n\r\n///variables can be assigned values either separately or on declaration\r\nvariableName = value; ///separate line assignment\r\n\r\nmodifier dataType variableName = value; ///same line assignment\r\n\r\n///implicitly typed variable\r\nvar variable2 = value;',
+                notes:
+                    'The modifier (public, private) permits or restricts direct access to the variable with respect to its scope (class, method, etc.). Variables declared within a class are called fields.\r\n\r\nVariables without a modifier are known as local variables, typically used within a method. They are temporary and only exist within the scope of the where its declared method.\r\n\r\ndataType is the data type of the variable. ',
+                example:
+                    'public class Car { \r\n    private int speed; ///private variable declaration\r\n    public int wheels; ///public variable declaration\r\n    \r\n    /*...constructor, etc...*/\r\n\r\n    public void speedUp() {\r\n        ///local variable declaration, in line assignment, only seen within speedUp method\r\n        int speedIncrease = 10;\r\n        speed += speedIncrease;\r\n    }\r\n}',
+                keywords: 'fields',
+                related:
+                    '<a href="/ref/csharp/access-mod">Access Modifiers</a>\r\n<a href="/ref/csharp/data-types">Primitive Data Types</a>',
+                documentation:
+                    '<a href="https://msdn.microsoft.com/en-us/library/ms173104.aspx">Types (C# Programming Reference) - MSDN</a>',
+                language_permalink: 'csharp',
+            };
+
+            it('should present the result', () => {
+                expect(getStub).to.not.have.been.called;
+                expect(resultsPresenter.showResults).to.not.have.been.called;
+
+                syntaxSearch.selectSearchResult({
+                    item: concept,
+                });
+
+                expect(
+                    resultsPresenter.showResults,
+                ).to.have.been.calledWithExactly(
+                    {
+                        item: concept,
+                    },
+                    resultView,
+                );
+            });
+        });
+        afterEach(() => {
+            getStub.restore();
         });
     });
 });


### PR DESCRIPTION
Syntax Filter:
<img width="808" alt="Screen Shot 2020-09-29 at 11 06 03 PM" src="https://user-images.githubusercontent.com/3276350/94767448-5ad90e80-037a-11eb-9272-35df1406d7f6.png">

Search:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/3276350/94767494-82c87200-037a-11eb-9132-539fb6b02e17.png">

If there's an issue connecting to internet, it will say "No internet" instead. Otherwise, a standard error message would be printed like above.